### PR TITLE
Add modern sport training calendar web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# sport-calendar
+# Sport Calendar
+
+Une application web moderne pour planifier, suivre et analyser tes séances de sport. L'interface propose une palette de sports avec drag-and-drop sur un calendrier hebdomadaire, une modale de détail riche et un coach IA intégré (Mistral) pour générer des idées d'entraînement.
+
+## Fonctionnalités
+
+- Authentification Firebase (création de compte, connexion, réinitialisation de mot de passe).
+- Vue calendrier par semaine (choix du premier jour, navigation par semaine, sélection rapide d'un mois).
+- Palette de sports drag-and-drop (judo, jjb, musculation, yoga, stretching, cardio).
+- Modale de saisie avec variations par sport, tags d'intensité et de sensations, planification ou reporting.
+- Sauvegarde et synchronisation temps réel des séances via Firestore.
+- Coach IA accessible depuis la palette ou la modale pour générer du contenu personnalisé grâce à l'API Mistral.
+
+## Prérequis
+
+- Navigateur moderne (Chrome, Edge, Firefox, Safari).
+- Configuration Firebase active (les clés de configuration sont déjà définies dans `app.js`).
+- Accès réseau sortant pour contacter Firebase et l'API Mistral.
+
+## Lancer le projet
+
+1. Clone le dépôt puis ouvre le dossier :
+
+   ```bash
+   git clone <repo>
+   cd sport-calendar
+   ```
+
+2. Sers les fichiers statiques avec ton serveur favori (exemples) :
+
+   ```bash
+   # Python 3
+   python -m http.server 5173
+
+   # ou avec Node.js (serve)
+   npx serve .
+   ```
+
+3. Ouvre [http://localhost:5173](http://localhost:5173) dans ton navigateur.
+
+4. Crée un compte ou connecte-toi pour accéder au calendrier.
+
+## Personnalisation
+
+- Les sports et leurs variations sont définis au début de `app.js` (`const sports = [...]`).
+- Les tags d'intensité et de sensation peuvent être ajustés dans `app.js` (`intensityOptions`, `feelingOptions`).
+- Le style général est géré dans `styles.css`. Les couleurs principales sont définies en variables CSS en tête du fichier.
+
+## Sécurité
+
+Les clés Firebase et la clé API Mistral sont utilisées côté client selon la configuration fournie. Pour un déploiement en production, envisage une couche backend ou des règles de sécurité strictes dans Firebase pour protéger tes données.
+
+## Licence
+
+Projet réalisé à des fins démonstratives. Ajuste la licence selon tes besoins.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,628 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
+import {
+  getAuth,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  updateProfile,
+  onAuthStateChanged,
+  signOut,
+  sendPasswordResetEmail,
+} from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js';
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  serverTimestamp,
+} from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyDwO-LeNjEBHzK5NHJlR0fPDNTXXTdHlSM',
+  authDomain: 'sport-calendar-ac287.firebaseapp.com',
+  projectId: 'sport-calendar-ac287',
+  storageBucket: 'sport-calendar-ac287.firebasestorage.app',
+  messagingSenderId: '448585132425',
+  appId: '1:448585132425:web:6fde5614752076ab2b5958',
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+const sports = [
+  {
+    id: 'judo',
+    name: 'Judo',
+    icon: '🥋',
+    color: 'linear-gradient(135deg, #7b5cff, #5a3bff)',
+    variations: ['Ne-waza', 'Randori', 'Technique', 'Kumi-kata', 'Conditioning'],
+  },
+  {
+    id: 'jjb',
+    name: 'Jiu-Jitsu Brésilien',
+    icon: '🥋',
+    color: 'linear-gradient(135deg, #5af8b9, #2ec4a3)',
+    variations: ['Drill', 'Sparring', 'Passages de garde', 'Soumissions', 'Escapes'],
+  },
+  {
+    id: 'strength',
+    name: 'Musculation',
+    icon: '🏋️',
+    color: 'linear-gradient(135deg, #ff6b6b, #ff8e53)',
+    variations: ['Force', 'Hypertrophie', 'Full body', 'Push/Pull', 'Core'],
+  },
+  {
+    id: 'yoga',
+    name: 'Yoga',
+    icon: '🧘',
+    color: 'linear-gradient(135deg, #26d4ff, #84f2ff)',
+    variations: ['Vinyasa', 'Hatha', 'Yin', 'Power', 'Respiration'],
+  },
+  {
+    id: 'stretch',
+    name: 'Stretching',
+    icon: '🤸',
+    color: 'linear-gradient(135deg, #ffb36b, #ffd56b)',
+    variations: ['Mobilité', 'Souplesse', 'Recovery', 'Full body'],
+  },
+  {
+    id: 'cardio',
+    name: 'Cardio',
+    icon: '🏃',
+    color: 'linear-gradient(135deg, #00f2fe, #4facfe)',
+    variations: ['HIIT', 'Endurance', 'Fractionné', 'Cyclisme', 'Course'],
+  },
+];
+
+const intensityOptions = ['Relax', 'Modérée', 'Soutenue', 'Intense', 'Max'];
+const feelingOptions = ['En pleine forme', 'Focus', 'Fatigué', 'Blessé', 'Flow'];
+
+const authView = document.getElementById('auth-view');
+const dashboard = document.getElementById('dashboard');
+const sportsList = document.getElementById('sports-list');
+const calendarGrid = document.getElementById('calendar-grid');
+const currentWeekLabel = document.getElementById('current-week');
+const currentMonthLabel = document.getElementById('current-month');
+const weekStartSelect = document.getElementById('week-start');
+const aiPanel = document.getElementById('ai-panel');
+const aiMessages = document.getElementById('ai-messages');
+const aiForm = document.getElementById('ai-form');
+const aiInput = document.getElementById('ai-input');
+const aiSuggestion = document.getElementById('ai-suggestion');
+
+let currentUser = null;
+let startDay = Number(weekStartSelect.value);
+let selectedWeekStart = getStartOfWeek(new Date(), startDay);
+let unsubscribeSessions = null;
+let slotHeight = 28;
+let sessionsCache = [];
+
+function toDateTimeLocalValue(date) {
+  const offset = date.getTimezoneOffset();
+  const local = new Date(date.getTime() - offset * 60000);
+  return local.toISOString().slice(0, 16);
+}
+
+function renderSports() {
+  sportsList.innerHTML = '';
+  sports.forEach((sport) => {
+    const pill = document.createElement('div');
+    pill.className = 'sport-pill';
+    pill.draggable = true;
+    pill.dataset.sportId = sport.id;
+    pill.innerHTML = `
+      <div class="sport-icon" style="background:${sport.color}">${sport.icon}</div>
+      <div class="sport-info">
+        <h3>${sport.name}</h3>
+        <p>${sport.variations[0]}</p>
+      </div>
+    `;
+
+    pill.addEventListener('dragstart', (event) => {
+      event.dataTransfer.setData('text/plain', sport.id);
+      event.dataTransfer.effectAllowed = 'copy';
+    });
+
+    sportsList.appendChild(pill);
+  });
+}
+
+function getStartOfWeek(date, startOfWeek = 1) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = (day < startOfWeek ? day + 7 : day) - startOfWeek;
+  d.setDate(d.getDate() - diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function renderCalendar() {
+  calendarGrid.innerHTML = '';
+  const headerRow = document.createElement('div');
+  headerRow.className = 'calendar-header-row';
+
+  const empty = document.createElement('div');
+  empty.className = 'calendar-header-cell';
+  headerRow.appendChild(empty);
+
+  const days = [];
+  for (let i = 0; i < 7; i += 1) {
+    const dayDate = new Date(selectedWeekStart);
+    dayDate.setDate(dayDate.getDate() + i);
+    days.push(dayDate);
+    const cell = document.createElement('div');
+    cell.className = 'calendar-header-cell';
+    const formatted = dayDate.toLocaleDateString('fr-FR', {
+      weekday: 'short',
+    });
+    cell.innerHTML = `<strong>${dayDate.getDate()}</strong>${formatted}`;
+    headerRow.appendChild(cell);
+  }
+
+  calendarGrid.appendChild(headerRow);
+
+  const body = document.createElement('div');
+  body.className = 'calendar-body';
+
+  for (let slot = 0; slot < 96; slot += 1) {
+    const row = document.createElement('div');
+    row.className = 'time-row';
+
+    const timeCell = document.createElement('div');
+    timeCell.className = 'time-cell';
+    const hours = Math.floor(slot / 4);
+    const minutes = (slot % 4) * 15;
+    const label = `${hours.toString().padStart(2, '0')}:${minutes
+      .toString()
+      .padStart(2, '0')}`;
+    timeCell.textContent = label;
+    row.appendChild(timeCell);
+
+    days.forEach((dayDate, dayIndex) => {
+      const dropCell = document.createElement('div');
+      dropCell.className = 'drop-cell';
+      dropCell.dataset.slot = slot;
+      dropCell.dataset.dayIndex = dayIndex;
+      dropCell.dataset.datetime = new Date(
+        dayDate.getFullYear(),
+        dayDate.getMonth(),
+        dayDate.getDate(),
+        hours,
+        minutes,
+      ).toISOString();
+
+      dropCell.addEventListener('dragover', (event) => {
+        event.preventDefault();
+        dropCell.classList.add('highlight');
+      });
+
+      dropCell.addEventListener('dragleave', () => {
+        dropCell.classList.remove('highlight');
+      });
+
+      dropCell.addEventListener('drop', (event) => {
+        event.preventDefault();
+        dropCell.classList.remove('highlight');
+        const sportId = event.dataTransfer.getData('text/plain');
+        const sport = sports.find((item) => item.id === sportId);
+        if (!sport) return;
+        openSessionModal({
+          sportId,
+          start: dropCell.dataset.datetime,
+        });
+      });
+
+      row.appendChild(dropCell);
+    });
+
+    body.appendChild(row);
+  }
+
+  calendarGrid.appendChild(body);
+  requestAnimationFrame(() => {
+    slotHeight = calendarGrid.querySelector('.drop-cell')?.offsetHeight || 28;
+    renderSessions();
+  });
+
+  updatePeriodLabels(days);
+}
+
+function updatePeriodLabels(days) {
+  const weekStart = days[0];
+  const weekEnd = days[6];
+  const formatter = new Intl.DateTimeFormat('fr-FR', {
+    month: 'long',
+    year: 'numeric',
+  });
+  const weekLabel = `${weekStart.getDate()} ${weekStart.toLocaleDateString('fr-FR', {
+    month: 'short',
+  })} – ${weekEnd.getDate()} ${weekEnd.toLocaleDateString('fr-FR', {
+    month: 'short',
+  })}`;
+  currentWeekLabel.textContent = weekLabel;
+  currentMonthLabel.textContent = formatter.format(weekStart);
+}
+
+function populateSelect(select, options) {
+  select.innerHTML = '';
+  options.forEach((option) => {
+    const element = document.createElement('option');
+    element.value = option;
+    element.textContent = option;
+    select.appendChild(element);
+  });
+}
+
+function populateChips(container, options) {
+  container.innerHTML = '';
+  options.forEach((option) => {
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'chip';
+    chip.textContent = option;
+    chip.addEventListener('click', () => {
+      chip.classList.toggle('selected');
+    });
+    container.appendChild(chip);
+  });
+}
+
+const sessionSportSelect = document.getElementById('session-sport');
+const sessionVariationSelect = document.getElementById('session-variation');
+const sessionStartInput = document.getElementById('session-start');
+const sessionDurationInput = document.getElementById('session-duration');
+const intensityContainer = document.getElementById('intensity-tags');
+const feelingContainer = document.getElementById('feeling-tags');
+const sessionModal = document.getElementById('session-modal');
+const modalTitle = document.getElementById('modal-title');
+const modalSubtitle = document.getElementById('modal-subtitle');
+const modalIcon = document.getElementById('modal-icon');
+const closeModalButton = document.getElementById('close-modal');
+const aiSuggestButton = document.getElementById('ai-suggest');
+
+populateSelect(sessionSportSelect, sports.map((sport) => sport.name));
+populateChips(intensityContainer, intensityOptions);
+populateChips(feelingContainer, feelingOptions);
+updateModalForSport(sports[0]);
+
+sessionSportSelect.addEventListener('change', () => {
+  const sport = sports.find((item) => item.name === sessionSportSelect.value);
+  updateModalForSport(sport || sports[0]);
+});
+
+function updateModalForSport(sport) {
+  sessionVariationSelect.innerHTML = '';
+  sport.variations.forEach((variation) => {
+    const option = document.createElement('option');
+    option.value = variation;
+    option.textContent = variation;
+    sessionVariationSelect.appendChild(option);
+  });
+  modalIcon.textContent = sport.icon;
+  modalTitle.textContent = `${sport.name}`;
+}
+
+function openSessionModal({ sportId, start }) {
+  const sport = sports.find((item) => item.id === sportId) || sports[0];
+  sessionSportSelect.value = sport.name;
+  updateModalForSport(sport);
+  sessionVariationSelect.value = sport.variations[0];
+  sessionStartInput.value = toDateTimeLocalValue(new Date(start));
+  sessionDurationInput.value = 60;
+  modalSubtitle.textContent = new Date(start).toLocaleString('fr-FR', {
+    weekday: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  intensityContainer.querySelectorAll('.chip').forEach((chip) => chip.classList.remove('selected'));
+  feelingContainer.querySelectorAll('.chip').forEach((chip) => chip.classList.remove('selected'));
+  aiSuggestion.classList.add('hidden');
+  aiSuggestion.textContent = '';
+  sessionModal.classList.remove('hidden');
+}
+
+function closeSessionModal() {
+  sessionModal.classList.add('hidden');
+}
+
+closeModalButton.addEventListener('click', closeSessionModal);
+sessionModal.addEventListener('click', (event) => {
+  if (event.target === sessionModal) {
+    closeSessionModal();
+  }
+});
+
+async function saveSession(event) {
+  event.preventDefault();
+  if (!currentUser) return;
+
+  const sport = sports.find((item) => item.name === sessionSportSelect.value);
+  const status = document.querySelector('input[name="session-status"]:checked').value;
+  const startDate = new Date(sessionStartInput.value);
+  const duration = Number(sessionDurationInput.value) || 60;
+  const intensity = Array.from(intensityContainer.querySelectorAll('.chip.selected')).map(
+    (chip) => chip.textContent,
+  );
+  const feelings = Array.from(feelingContainer.querySelectorAll('.chip.selected')).map(
+    (chip) => chip.textContent,
+  );
+
+  const payload = {
+    userId: currentUser.uid,
+    sportId: sport.id,
+    sportName: sport.name,
+    variation: sessionVariationSelect.value,
+    start: startDate.toISOString(),
+    duration,
+    intensity,
+    feelings,
+    status,
+    createdAt: serverTimestamp(),
+  };
+
+  try {
+    await addDoc(collection(db, 'sessions'), payload);
+    closeSessionModal();
+  } catch (error) {
+    console.error(error);
+    alert("Impossible d'enregistrer la séance. Réessaie plus tard.");
+  }
+}
+
+document.getElementById('session-form').addEventListener('submit', saveSession);
+
+function renderSessions() {
+  calendarGrid.querySelectorAll('.session-block').forEach((block) => block.remove());
+  sessionsCache.forEach((session) => {
+    const startDate = new Date(session.start);
+    const dayIndex = Math.floor((startDate - selectedWeekStart) / (1000 * 60 * 60 * 24));
+    if (dayIndex < 0 || dayIndex > 6) return;
+    const startSlot = startDate.getHours() * 4 + Math.floor(startDate.getMinutes() / 15);
+    const slots = Math.max(1, Math.round(session.duration / 15));
+    const targetCell = calendarGrid.querySelector(
+      `.drop-cell[data-day-index="${dayIndex}"][data-slot="${startSlot}"]`,
+    );
+    if (!targetCell) return;
+
+    const block = document.createElement('div');
+    block.className = `session-block ${session.status === 'completed' ? 'completed' : 'planned'}`;
+    block.style.height = `${slots * slotHeight - 8}px`;
+    block.style.background = session.status === 'completed'
+      ? 'linear-gradient(135deg, rgba(68, 255, 161, 0.85), rgba(32, 201, 151, 0.95))'
+      : 'linear-gradient(135deg, rgba(123, 92, 255, 0.8), rgba(38, 212, 255, 0.9))';
+    block.innerHTML = `
+      <strong>${session.sportName}</strong>
+      <span>${session.variation}</span>
+      <div class="session-meta">
+        <span>${new Date(session.start).toLocaleTimeString('fr-FR', {
+          hour: '2-digit',
+          minute: '2-digit',
+        })}</span>
+        <span>${session.duration} min</span>
+      </div>
+    `;
+    targetCell.appendChild(block);
+  });
+}
+
+function subscribeToSessions() {
+  if (!currentUser) return;
+  if (unsubscribeSessions) unsubscribeSessions();
+
+  const weekEnd = new Date(selectedWeekStart);
+  weekEnd.setDate(weekEnd.getDate() + 7);
+
+  const sessionsQuery = query(
+    collection(db, 'sessions'),
+    where('userId', '==', currentUser.uid),
+    where('start', '>=', selectedWeekStart.toISOString()),
+    where('start', '<', weekEnd.toISOString()),
+    orderBy('start', 'asc'),
+  );
+
+  unsubscribeSessions = onSnapshot(
+    sessionsQuery,
+    (snapshot) => {
+      sessionsCache = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+      renderSessions();
+    },
+    (error) => {
+      console.error(error);
+    },
+  );
+}
+
+function changeWeek(offset) {
+  selectedWeekStart.setDate(selectedWeekStart.getDate() + offset * 7);
+  renderCalendar();
+  subscribeToSessions();
+}
+
+function openMonthPicker() {
+  const current = selectedWeekStart.toISOString().slice(0, 7);
+  const input = prompt('Choisis un mois (AAAA-MM)', current);
+  if (!input) return;
+  const [year, month] = input.split('-').map(Number);
+  if (Number.isNaN(year) || Number.isNaN(month)) return;
+  selectedWeekStart = getStartOfWeek(new Date(year, month - 1, 1), startDay);
+  renderCalendar();
+  subscribeToSessions();
+}
+
+function toggleAIPanel(show) {
+  if (show) {
+    aiPanel.classList.remove('hidden');
+  } else {
+    aiPanel.classList.add('hidden');
+  }
+}
+
+async function callMistral(prompt) {
+  const response = await fetch('https://api.mistral.ai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer uW9AaHXECYi1wn0EJHmh2OelX1KDx3ee',
+    },
+    body: JSON.stringify({
+      model: 'mistral-small-latest',
+      messages: [
+        {
+          role: 'system',
+          content:
+            "Tu es un coach sportif qui conçoit des entraînements personnalisés et motivants. Fournis des réponses structurées, avec des listes quand c'est pertinent.",
+        },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0.7,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('API IA indisponible');
+  }
+
+  const data = await response.json();
+  return data.choices?.[0]?.message?.content ?? '';
+}
+
+aiForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const question = aiInput.value.trim();
+  if (!question) return;
+
+  const userBubble = document.createElement('div');
+  userBubble.className = 'ai-message user';
+  userBubble.textContent = question;
+  aiMessages.appendChild(userBubble);
+  aiMessages.scrollTop = aiMessages.scrollHeight;
+
+  aiInput.value = '';
+
+  const loadingBubble = document.createElement('div');
+  loadingBubble.className = 'ai-message';
+  loadingBubble.textContent = 'Réflexion en cours...';
+  aiMessages.appendChild(loadingBubble);
+  aiMessages.scrollTop = aiMessages.scrollHeight;
+
+  try {
+    const reply = await callMistral(question);
+    loadingBubble.textContent = reply;
+  } catch (error) {
+    loadingBubble.textContent = "L'IA n'a pas pu répondre pour le moment.";
+  }
+});
+
+aiSuggestButton.addEventListener('click', async () => {
+  const sport = sports.find((item) => item.name === sessionSportSelect.value);
+  const start = new Date(sessionStartInput.value);
+  const status = document.querySelector('input[name="session-status"]:checked').value;
+  const context = `Je prépare une séance de ${sport.name} (${sport.id}) ${
+    status === 'planned' ? 'planifiée' : 'déjà réalisée'
+  } le ${start.toLocaleString('fr-FR', {
+    weekday: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  })} pour ${sessionDurationInput.value} minutes. Propose un contenu structuré avec variation, travail par segment et conseils.`;
+
+  aiSuggestion.classList.remove('hidden');
+  aiSuggestion.textContent = 'Génération de ta séance personnalisée...';
+
+  try {
+    const reply = await callMistral(context);
+    aiSuggestion.textContent = reply;
+  } catch (error) {
+    aiSuggestion.textContent = "Impossible de récupérer une suggestion IA pour le moment.";
+  }
+});
+
+function attachAuthHandlers() {
+  const tabs = document.querySelectorAll('.tab');
+  const forms = document.querySelectorAll('.form');
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      tabs.forEach((item) => item.classList.remove('active'));
+      forms.forEach((form) => form.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById(tab.dataset.target).classList.add('active');
+    });
+  });
+
+  document.getElementById('login-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const email = document.getElementById('login-email').value;
+    const password = document.getElementById('login-password').value;
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+    } catch (error) {
+      alert('Connexion impossible. Vérifie tes identifiants.');
+    }
+  });
+
+  document.getElementById('signup-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const email = document.getElementById('signup-email').value;
+    const password = document.getElementById('signup-password').value;
+    const name = document.getElementById('signup-name').value;
+    try {
+      const { user } = await createUserWithEmailAndPassword(auth, email, password);
+      await updateProfile(user, { displayName: name });
+    } catch (error) {
+      alert('Création de compte impossible. Vérifie tes informations.');
+    }
+  });
+
+  document.getElementById('logout').addEventListener('click', () => signOut(auth));
+
+  document.getElementById('reset-link').addEventListener('click', async (event) => {
+    event.preventDefault();
+    const email = prompt('Indique ton email pour réinitialiser ton mot de passe');
+    if (!email) return;
+    try {
+      await sendPasswordResetEmail(auth, email);
+      alert('Email envoyé ! Vérifie ta boîte de réception.');
+    } catch (error) {
+      alert("Impossible d'envoyer l'email. Vérifie l'adresse renseignée.");
+    }
+  });
+}
+
+function initNavigation() {
+  document.getElementById('prev-week').addEventListener('click', () => changeWeek(-1));
+  document.getElementById('next-week').addEventListener('click', () => changeWeek(1));
+  document.getElementById('month-picker').addEventListener('click', openMonthPicker);
+  document.getElementById('ai-builder').addEventListener('click', () => toggleAIPanel(true));
+  document.getElementById('ai-chat-trigger').addEventListener('click', () => toggleAIPanel(true));
+  document.getElementById('close-ai').addEventListener('click', () => toggleAIPanel(false));
+
+  weekStartSelect.addEventListener('change', () => {
+    startDay = Number(weekStartSelect.value);
+    selectedWeekStart = getStartOfWeek(selectedWeekStart, startDay);
+    renderCalendar();
+    subscribeToSessions();
+  });
+}
+
+attachAuthHandlers();
+initNavigation();
+renderSports();
+renderCalendar();
+
+onAuthStateChanged(auth, (user) => {
+  currentUser = user;
+  if (user) {
+    authView.classList.add('hidden');
+    dashboard.classList.remove('hidden');
+    selectedWeekStart = getStartOfWeek(new Date(), startDay);
+    renderCalendar();
+    subscribeToSessions();
+  } else {
+    dashboard.classList.add('hidden');
+    authView.classList.remove('hidden');
+    if (unsubscribeSessions) unsubscribeSessions();
+    sessionsCache = [];
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sport Calendar</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="background-gradient"></div>
+    <div id="app" class="app-shell">
+      <div class="auth-card" id="auth-view">
+        <div class="auth-hero">
+          <h1>Sport<span>Flow</span></h1>
+          <p>
+            Planifie tes entraînements, visualise ta progression et laisse notre
+            IA t'aider à construire des séances mémorables.
+          </p>
+        </div>
+        <div class="auth-forms">
+          <div class="tabs">
+            <button class="tab active" data-target="login-form">Connexion</button>
+            <button class="tab" data-target="signup-form">Créer un compte</button>
+          </div>
+          <form id="login-form" class="form active">
+            <label>Email</label>
+            <input type="email" id="login-email" placeholder="email@exemple.com" required />
+            <label>Mot de passe</label>
+            <input type="password" id="login-password" placeholder="••••••••" required />
+            <button type="submit" class="primary">Se connecter</button>
+            <p class="auth-hint">Mot de passe oublié ? <a href="#" id="reset-link">Réinitialiser</a></p>
+          </form>
+          <form id="signup-form" class="form">
+            <label>Nom</label>
+            <input type="text" id="signup-name" placeholder="Prénom Nom" required />
+            <label>Email</label>
+            <input type="email" id="signup-email" placeholder="email@exemple.com" required />
+            <label>Mot de passe</label>
+            <input type="password" id="signup-password" placeholder="••••••••" minlength="6" required />
+            <button type="submit" class="primary">Créer mon compte</button>
+          </form>
+        </div>
+      </div>
+
+      <main id="dashboard" class="dashboard hidden">
+        <header class="topbar">
+          <div class="brand">Sport<span>Flow</span></div>
+          <div class="topbar-actions">
+            <div class="start-week-selector">
+              <label for="week-start">Semaine à partir de</label>
+              <select id="week-start">
+                <option value="1" selected>Lundi</option>
+                <option value="0">Dimanche</option>
+                <option value="2">Mardi</option>
+                <option value="3">Mercredi</option>
+                <option value="4">Jeudi</option>
+                <option value="5">Vendredi</option>
+                <option value="6">Samedi</option>
+              </select>
+            </div>
+            <button id="logout" class="ghost">Déconnexion</button>
+          </div>
+        </header>
+
+        <section class="planner">
+          <aside class="sports-palette">
+            <div class="palette-header">
+              <h2>Tes sports</h2>
+              <button id="ai-builder" class="icon-button" title="Assistant séance">
+                <span aria-hidden="true">🤖</span>
+              </button>
+            </div>
+            <p class="palette-subtitle">Glisse la pastille sur le créneau souhaité.</p>
+            <div id="sports-list" class="sports-list"></div>
+          </aside>
+
+          <section class="calendar-area">
+            <div class="calendar-header">
+              <div class="calendar-legend">
+                <div class="legend-item planning">Planifiée</div>
+                <div class="legend-item completed">Réalisée</div>
+              </div>
+              <button id="ai-chat-trigger" class="icon-button" title="Coach IA">
+                <span aria-hidden="true">💬</span>
+              </button>
+              <div class="calendar-navigation">
+                <button id="prev-week" class="nav-button">⟵ Semaine</button>
+                <div class="current-period">
+                  <h2 id="current-week"></h2>
+                  <p id="current-month"></p>
+                </div>
+                <button id="next-week" class="nav-button">Semaine ⟶</button>
+              </div>
+              <button id="month-picker" class="ghost">Changer de mois</button>
+            </div>
+            <div class="calendar-grid" id="calendar-grid"></div>
+          </section>
+        </section>
+      </main>
+
+      <div id="session-modal" class="modal hidden" role="dialog" aria-modal="true">
+        <div class="modal-content">
+          <button class="icon-button close" id="close-modal" aria-label="Fermer">✕</button>
+          <div class="modal-header">
+            <div class="modal-icon" id="modal-icon">🥋</div>
+            <div>
+              <h3 id="modal-title">Nouvelle séance</h3>
+              <p id="modal-subtitle"></p>
+            </div>
+          </div>
+          <form id="session-form">
+            <div class="form-grid">
+              <label>
+                Sport
+                <select id="session-sport" required></select>
+              </label>
+              <label>
+                Variation
+                <select id="session-variation" required></select>
+              </label>
+              <label>
+                Début
+                <input type="datetime-local" id="session-start" required />
+              </label>
+              <label>
+                Durée (minutes)
+                <input type="number" id="session-duration" min="15" step="15" value="60" />
+              </label>
+            </div>
+            <div class="chips-group">
+              <p class="chips-title">Intensité</p>
+              <div id="intensity-tags" class="chips"></div>
+            </div>
+            <div class="chips-group">
+              <p class="chips-title">Sensations</p>
+              <div id="feeling-tags" class="chips"></div>
+            </div>
+            <div id="ai-suggestion" class="ai-suggestion hidden"></div>
+            <div class="session-type">
+              <label>
+                <input type="radio" name="session-status" value="planned" checked /> Planification
+              </label>
+              <label>
+                <input type="radio" name="session-status" value="completed" /> Reporting
+              </label>
+            </div>
+            <div class="modal-actions">
+              <button type="button" class="ghost" id="ai-suggest">Proposer avec l'IA</button>
+              <button type="submit" class="primary">Enregistrer</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div id="ai-panel" class="ai-panel hidden">
+        <div class="ai-header">
+          <h3>Coach IA</h3>
+          <button class="icon-button" id="close-ai">✕</button>
+        </div>
+        <div id="ai-messages" class="ai-messages"></div>
+        <form id="ai-form" class="ai-form">
+          <input id="ai-input" type="text" placeholder="Pose ta question ou demande une séance..." required />
+          <button type="submit" class="primary">Envoyer</button>
+        </form>
+      </div>
+    </div>
+
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,697 @@
+:root {
+  color-scheme: light;
+  font-family: 'Outfit', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --bg: #06060f;
+  --fg: #f8f9fc;
+  --muted: rgba(248, 249, 252, 0.6);
+  --accent: linear-gradient(135deg, #7b5cff 0%, #26d4ff 100%);
+  --accent-solid: #6e5bff;
+  --accent-2: linear-gradient(135deg, #ff6b6b, #ffb36b);
+  --card-bg: rgba(12, 13, 26, 0.8);
+  --border: rgba(255, 255, 255, 0.08);
+  --shadow: 0 20px 45px rgba(8, 8, 20, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--fg);
+  overflow-x: hidden;
+}
+
+.background-gradient {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(123, 92, 255, 0.45), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(38, 212, 255, 0.35), transparent 45%),
+    radial-gradient(circle at 50% 80%, rgba(255, 107, 107, 0.25), transparent 40%);
+  filter: blur(60px);
+  z-index: 0;
+}
+
+.app-shell {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  z-index: 1;
+}
+
+.auth-card {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  background: rgba(9, 11, 22, 0.85);
+  border: 1px solid var(--border);
+  border-radius: 30px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  width: min(950px, 100%);
+}
+
+.auth-hero {
+  padding: 3rem 3.5rem;
+  background: radial-gradient(circle at top right, rgba(110, 91, 255, 0.25), transparent 55%),
+    rgba(10, 11, 24, 0.9);
+}
+
+.auth-hero h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  margin: 0 0 1rem;
+  letter-spacing: -1px;
+}
+
+.auth-hero span {
+  background: var(--accent);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.auth-hero p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.auth-forms {
+  padding: 3rem 3rem 3.5rem;
+  backdrop-filter: blur(16px);
+}
+
+.tabs {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.tab {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--muted);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab.active {
+  background: var(--accent);
+  color: var(--fg);
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 15px 35px rgba(110, 91, 255, 0.35);
+}
+
+.form {
+  display: none;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.form.active {
+  display: flex;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+input,
+select {
+  padding: 0.8rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--fg);
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: rgba(110, 91, 255, 0.75);
+  box-shadow: 0 0 0 4px rgba(110, 91, 255, 0.25);
+}
+
+.primary {
+  background: var(--accent);
+  border: none;
+  color: var(--fg);
+  padding: 0.95rem 1.4rem;
+  border-radius: 16px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(123, 92, 255, 0.45);
+}
+
+.ghost {
+  padding: 0.75rem 1.2rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.icon-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--fg);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.material-symbol {
+  font-size: 1.3rem;
+}
+
+.auth-hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.auth-hint a {
+  color: var(--fg);
+}
+
+.dashboard {
+  width: min(1280px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 2rem;
+  background: rgba(9, 10, 20, 0.9);
+  border-radius: 28px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 1.6rem;
+}
+
+.brand span {
+  background: var(--accent);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.start-week-selector label {
+  font-size: 0.9rem;
+  color: var(--muted);
+  margin-bottom: 0.2rem;
+}
+
+.start-week-selector select {
+  width: 140px;
+}
+
+.planner {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 1.5rem;
+}
+
+.sports-palette {
+  background: rgba(9, 10, 20, 0.85);
+  border-radius: 28px;
+  padding: 1.8rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 720px;
+}
+
+.palette-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.palette-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.sports-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sport-pill {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: grab;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sport-pill:active {
+  cursor: grabbing;
+  transform: scale(0.97);
+}
+
+.sport-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.sport-info h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.sport-info p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.calendar-area {
+  background: rgba(9, 10, 20, 0.85);
+  border-radius: 28px;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.calendar-header {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 1rem;
+  align-items: center;
+}
+
+.calendar-legend {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.legend-item {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.legend-item.planning {
+  background: rgba(123, 92, 255, 0.2);
+}
+
+.legend-item.completed {
+  background: rgba(68, 255, 161, 0.2);
+}
+
+.calendar-navigation {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.2rem;
+}
+
+.current-period h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.current-period p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.nav-button {
+  padding: 0.65rem 1rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.calendar-grid {
+  position: relative;
+  border-radius: 22px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 11, 24, 0.8);
+}
+
+.calendar-grid::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(110, 91, 255, 0.1), transparent 30%);
+  pointer-events: none;
+}
+
+.calendar-header-row,
+.time-row {
+  display: grid;
+  grid-template-columns: 80px repeat(7, 1fr);
+}
+
+.calendar-header-row {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: rgba(9, 10, 20, 0.95);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.calendar-header-cell {
+  padding: 0.9rem 1rem;
+  text-align: center;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.calendar-header-cell strong {
+  display: block;
+  font-size: 1.05rem;
+  color: var(--fg);
+}
+
+.calendar-body {
+  max-height: 620px;
+  overflow-y: auto;
+}
+
+.time-cell {
+  padding: 0.4rem 0.6rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  background: rgba(9, 10, 20, 0.6);
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+
+.drop-cell {
+  border-left: 1px solid rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  position: relative;
+  min-height: 28px;
+  overflow: visible;
+  transition: background 0.2s ease;
+}
+
+.drop-cell.highlight {
+  background: rgba(110, 91, 255, 0.15);
+}
+
+.session-block {
+  position: absolute;
+  inset: 4px 6px;
+  border-radius: 18px;
+  padding: 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: #0b0c17;
+  font-weight: 600;
+  box-shadow: 0 15px 25px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+
+.session-block span {
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.session-block.planned {
+  background: linear-gradient(135deg, rgba(123, 92, 255, 0.8), rgba(38, 212, 255, 0.9));
+}
+
+.session-block.completed {
+  background: linear-gradient(135deg, rgba(68, 255, 161, 0.85), rgba(32, 201, 151, 0.95));
+}
+
+.session-block .session-meta {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 4, 10, 0.65);
+  display: grid;
+  place-items: center;
+  z-index: 20;
+  backdrop-filter: blur(14px);
+}
+
+.modal-content {
+  width: min(560px, 90%);
+  background: rgba(9, 10, 20, 0.95);
+  border-radius: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  padding: 2.2rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.modal-header {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.modal-icon {
+  width: 60px;
+  height: 60px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.08);
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+}
+
+.modal h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.modal p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.chips-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chips-title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.ai-suggestion {
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(123, 92, 255, 0.3);
+  background: rgba(123, 92, 255, 0.15);
+  color: var(--fg);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.chip {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chip.selected {
+  background: var(--accent);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.session-type {
+  display: flex;
+  gap: 1rem;
+  font-weight: 600;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.ai-panel {
+  position: fixed;
+  right: 2rem;
+  bottom: 2rem;
+  width: min(360px, 90vw);
+  background: rgba(9, 10, 20, 0.95);
+  border-radius: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  z-index: 30;
+}
+
+.ai-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ai-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.ai-message {
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.ai-message.user {
+  align-self: flex-end;
+  background: rgba(123, 92, 255, 0.35);
+}
+
+.ai-form {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ai-form input {
+  flex: 1;
+}
+
+@media (max-width: 1100px) {
+  .planner {
+    grid-template-columns: 1fr;
+  }
+  .sports-palette {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .auth-card {
+    grid-template-columns: 1fr;
+  }
+  .auth-hero {
+    padding: 2.5rem 2rem;
+  }
+  .auth-forms {
+    padding: 2rem;
+  }
+  .topbar {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+  .calendar-header {
+    grid-template-columns: 1fr;
+  }
+  .calendar-header-row,
+  .time-row {
+    grid-template-columns: 60px repeat(7, 1fr);
+  }
+  .time-cell {
+    font-size: 0.65rem;
+  }
+}


### PR DESCRIPTION
## Summary
- build a single-page SportFlow experience with Firebase auth, drag-and-drop sports palette, and week calendar views
- add immersive styling, AI assistant hooks, and modal workflow for planning or reporting sessions
- document setup, prerequisites, and customization guidance in the README

## Testing
- manual UI verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68da09eb87048328a719d46e5672722f