### PR TITLE
Add dark/light theme toggle and modern icon set

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,42 +36,42 @@ const sports = [
   {
     id: 'judo',
     name: 'Judo',
-    icon: '🥋',
+    icon: 'sports_martial_arts',
     color: 'linear-gradient(135deg, #7b5cff, #5a3bff)',
     variations: ['Ne-waza', 'Randori', 'Technique', 'Kumi-kata', 'Conditioning'],
   },
   {
     id: 'jjb',
     name: 'Jiu-Jitsu Brésilien',
-    icon: '🥋',
+    icon: 'sports_mma',
     color: 'linear-gradient(135deg, #5af8b9, #2ec4a3)',
     variations: ['Drill', 'Sparring', 'Passages de garde', 'Soumissions', 'Escapes'],
   },
   {
     id: 'strength',
     name: 'Musculation',
-    icon: '🏋️',
+    icon: 'fitness_center',
     color: 'linear-gradient(135deg, #ff6b6b, #ff8e53)',
     variations: ['Force', 'Hypertrophie', 'Full body', 'Push/Pull', 'Core'],
   },
   {
     id: 'yoga',
     name: 'Yoga',
-    icon: '🧘',
+    icon: 'self_improvement',
     color: 'linear-gradient(135deg, #26d4ff, #84f2ff)',
     variations: ['Vinyasa', 'Hatha', 'Yin', 'Power', 'Respiration'],
   },
   {
     id: 'stretch',
     name: 'Stretching',
-    icon: '🤸',
+    icon: 'accessibility_new',
     color: 'linear-gradient(135deg, #ffb36b, #ffd56b)',
     variations: ['Mobilité', 'Souplesse', 'Recovery', 'Full body'],
   },
   {
     id: 'cardio',
     name: 'Cardio',
-    icon: '🏃',
+    icon: 'directions_run',
     color: 'linear-gradient(135deg, #00f2fe, #4facfe)',
     variations: ['HIIT', 'Endurance', 'Fractionné', 'Cyclisme', 'Course'],
   },
@@ -92,6 +92,52 @@ const aiMessages = document.getElementById('ai-messages');
 const aiForm = document.getElementById('ai-form');
 const aiInput = document.getElementById('ai-input');
 const aiSuggestion = document.getElementById('ai-suggestion');
+const themeToggleButtons = [
+  document.getElementById('theme-toggle'),
+  document.getElementById('dashboard-theme-toggle'),
+].filter(Boolean);
+
+const THEME_STORAGE_KEY = 'sportflow-theme';
+
+function updateThemeToggleButtons(theme) {
+  const isLight = theme === 'light';
+  const iconName = isLight ? 'dark_mode' : 'light_mode';
+  const label = isLight ? 'Activer le mode sombre' : 'Activer le mode clair';
+  themeToggleButtons.forEach((button) => {
+    button.setAttribute('aria-label', label);
+    button.setAttribute('title', label);
+    const iconElement = button.querySelector('.material-symbols-rounded');
+    if (iconElement) {
+      iconElement.textContent = iconName;
+    }
+  });
+}
+
+function applyTheme(theme) {
+  document.body.dataset.theme = theme;
+  updateThemeToggleButtons(theme);
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch (error) {
+    // Local storage may be unavailable (private mode, etc.)
+  }
+}
+
+let storedTheme = null;
+try {
+  storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+} catch (error) {
+  storedTheme = null;
+}
+
+applyTheme(storedTheme || 'dark');
+
+themeToggleButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const nextTheme = document.body.dataset.theme === 'light' ? 'dark' : 'light';
+    applyTheme(nextTheme);
+  });
+});
 
 let currentUser = null;
 let startDay = Number(weekStartSelect.value);
@@ -114,7 +160,9 @@ function renderSports() {
     pill.draggable = true;
     pill.dataset.sportId = sport.id;
     pill.innerHTML = `
-      <div class="sport-icon" style="background:${sport.color}">${sport.icon}</div>
+      <div class="sport-icon" style="background:${sport.color}">
+        <span class="material-symbols-rounded" aria-hidden="true">${sport.icon}</span>
+      </div>
       <div class="sport-info">
         <h3>${sport.name}</h3>
         <p>${sport.variations[0]}</p>
@@ -301,7 +349,8 @@ function updateModalForSport(sport) {
     option.textContent = variation;
     sessionVariationSelect.appendChild(option);
   });
-  modalIcon.textContent = sport.icon;
+  modalIcon.innerHTML = `<span class="material-symbols-rounded" aria-hidden="true">${sport.icon}</span>`;
+  modalIcon.style.background = sport.color;
   modalTitle.textContent = `${sport.name}`;
 }
 
@@ -560,7 +609,10 @@ function attachAuthHandlers() {
   function togglePasswordVisibility(input, toggle) {
     const isPassword = input.type === 'password';
     input.type = isPassword ? 'text' : 'password';
-    toggle.textContent = isPassword ? '🙈' : '👁️';
+    const iconElement = toggle.querySelector('.material-symbols-rounded');
+    if (iconElement) {
+      iconElement.textContent = isPassword ? 'visibility_off' : 'visibility';
+    }
     toggle.setAttribute('aria-label', isPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe');
   }
 

--- a/images/.gitkeep
+++ b/images/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for forthcoming image assets.

--- a/index.html
+++ b/index.html
@@ -10,9 +10,21 @@
       href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,400,0,0"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <button
+      id="theme-toggle"
+      class="theme-toggle icon-button"
+      type="button"
+      aria-label="Activer le mode clair"
+    >
+      <span class="material-symbols-rounded" aria-hidden="true">light_mode</span>
+    </button>
     <div class="background-gradient"></div>
     <div id="app" class="app-shell">
       <div class="auth-card" id="auth-view">
@@ -34,10 +46,15 @@
             <label>Mot de passe</label>
             <div class="password-input-container">
               <input type="password" id="login-password" placeholder="••••••••" required />
-              <button type="button" class="password-toggle" id="login-password-toggle" aria-label="Afficher le mot de passe">👁️</button>
+              <button type="button" class="password-toggle" id="login-password-toggle" aria-label="Afficher le mot de passe">
+                <span class="material-symbols-rounded" aria-hidden="true">visibility</span>
+              </button>
             </div>
             <button type="submit" class="primary">Se connecter</button>
-            <button type="button" class="dev-login" id="dev-login-btn">🚀 Connexion rapide (dev)</button>
+            <button type="button" class="dev-login" id="dev-login-btn">
+              <span class="material-symbols-rounded" aria-hidden="true">rocket_launch</span>
+              Connexion rapide (dev)
+            </button>
             <p class="auth-hint">Mot de passe oublié ? <a href="#" id="reset-link">Réinitialiser</a></p>
           </form>
           <form id="signup-form" class="form">
@@ -48,7 +65,9 @@
             <label>Mot de passe</label>
             <div class="password-input-container">
               <input type="password" id="signup-password" placeholder="••••••••" minlength="6" required />
-              <button type="button" class="password-toggle" id="signup-password-toggle" aria-label="Afficher le mot de passe">👁️</button>
+              <button type="button" class="password-toggle" id="signup-password-toggle" aria-label="Afficher le mot de passe">
+                <span class="material-symbols-rounded" aria-hidden="true">visibility</span>
+              </button>
             </div>
             <button type="submit" class="primary">Créer mon compte</button>
           </form>
@@ -71,6 +90,9 @@
                 <option value="6">Samedi</option>
               </select>
             </div>
+            <button id="dashboard-theme-toggle" class="icon-button" type="button" aria-label="Activer le mode clair">
+              <span class="material-symbols-rounded" aria-hidden="true">light_mode</span>
+            </button>
             <button id="logout" class="ghost">Déconnexion</button>
           </div>
         </header>
@@ -80,7 +102,7 @@
             <div class="palette-header">
               <h2>Tes sports</h2>
               <button id="ai-builder" class="icon-button" title="Assistant séance">
-                <span aria-hidden="true">🤖</span>
+                <span class="material-symbols-rounded" aria-hidden="true">robot_2</span>
               </button>
             </div>
             <p class="palette-subtitle">Glisse la pastille sur le créneau souhaité.</p>
@@ -94,15 +116,21 @@
                 <div class="legend-item completed">Réalisée</div>
               </div>
               <button id="ai-chat-trigger" class="icon-button" title="Coach IA">
-                <span aria-hidden="true">💬</span>
+                <span class="material-symbols-rounded" aria-hidden="true">forum</span>
               </button>
               <div class="calendar-navigation">
-                <button id="prev-week" class="nav-button">⟵ Semaine</button>
+                <button id="prev-week" class="nav-button">
+                  <span class="material-symbols-rounded" aria-hidden="true">chevron_left</span>
+                  Semaine
+                </button>
                 <div class="current-period">
                   <h2 id="current-week"></h2>
                   <p id="current-month"></p>
                 </div>
-                <button id="next-week" class="nav-button">Semaine ⟶</button>
+                <button id="next-week" class="nav-button">
+                  Semaine
+                  <span class="material-symbols-rounded" aria-hidden="true">chevron_right</span>
+                </button>
               </div>
               <button id="month-picker" class="ghost">Changer de mois</button>
             </div>
@@ -113,9 +141,13 @@
 
       <div id="session-modal" class="modal hidden" role="dialog" aria-modal="true">
         <div class="modal-content">
-          <button class="icon-button close" id="close-modal" aria-label="Fermer">✕</button>
+          <button class="icon-button close" id="close-modal" aria-label="Fermer">
+            <span class="material-symbols-rounded" aria-hidden="true">close</span>
+          </button>
           <div class="modal-header">
-            <div class="modal-icon" id="modal-icon">🥋</div>
+            <div class="modal-icon" id="modal-icon">
+              <span class="material-symbols-rounded" aria-hidden="true">sports_martial_arts</span>
+            </div>
             <div>
               <h3 id="modal-title">Nouvelle séance</h3>
               <p id="modal-subtitle"></p>
@@ -168,7 +200,9 @@
       <div id="ai-panel" class="ai-panel hidden">
         <div class="ai-header">
           <h3>Coach IA</h3>
-          <button class="icon-button" id="close-ai">✕</button>
+          <button class="icon-button" id="close-ai" aria-label="Fermer le coach IA">
+            <span class="material-symbols-rounded" aria-hidden="true">close</span>
+          </button>
         </div>
         <div id="ai-messages" class="ai-messages"></div>
         <form id="ai-form" class="ai-form">

--- a/styles.css
+++ b/styles.css
@@ -1,16 +1,45 @@
 :root {
-  color-scheme: light;
   font-family: 'Outfit', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
+  color-scheme: dark;
   --bg: #06060f;
   --fg: #f8f9fc;
-  --muted: rgba(248, 249, 252, 0.6);
+  --muted: rgba(248, 249, 252, 0.65);
   --accent: linear-gradient(135deg, #7b5cff 0%, #26d4ff 100%);
   --accent-solid: #6e5bff;
   --accent-2: linear-gradient(135deg, #ff6b6b, #ffb36b);
-  --card-bg: rgba(12, 13, 26, 0.8);
   --border: rgba(255, 255, 255, 0.08);
   --shadow: 0 20px 45px rgba(8, 8, 20, 0.35);
+  --surface-strong: rgba(9, 10, 20, 0.9);
+  --surface-mid: rgba(12, 13, 26, 0.85);
+  --surface-soft: rgba(255, 255, 255, 0.05);
+  --surface-border: rgba(255, 255, 255, 0.08);
+  --ghost-hover: rgba(255, 255, 255, 0.14);
+  --input-bg: rgba(255, 255, 255, 0.04);
+  --input-border: rgba(255, 255, 255, 0.08);
+  --legend-planning: rgba(123, 92, 255, 0.2);
+  --legend-completed: rgba(68, 255, 161, 0.2);
+}
+
+body[data-theme='light'] {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --fg: #0b0d1a;
+  --muted: rgba(11, 13, 26, 0.6);
+  --accent: linear-gradient(135deg, #6e5bff 0%, #26d4ff 100%);
+  --accent-solid: #5b4af6;
+  --accent-2: linear-gradient(135deg, #ff6b6b, #ffb36b);
+  --border: rgba(11, 13, 26, 0.08);
+  --shadow: 0 12px 35px rgba(22, 26, 49, 0.15);
+  --surface-strong: rgba(255, 255, 255, 0.96);
+  --surface-mid: rgba(255, 255, 255, 0.92);
+  --surface-soft: rgba(11, 13, 26, 0.05);
+  --surface-border: rgba(11, 13, 26, 0.1);
+  --ghost-hover: rgba(11, 13, 26, 0.12);
+  --input-bg: rgba(11, 13, 26, 0.06);
+  --input-border: rgba(11, 13, 26, 0.1);
+  --legend-planning: rgba(123, 92, 255, 0.14);
+  --legend-completed: rgba(68, 255, 161, 0.18);
 }
 
 * {
@@ -23,6 +52,7 @@ body {
   background: var(--bg);
   color: var(--fg);
   overflow-x: hidden;
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
 .background-gradient {
@@ -33,6 +63,12 @@ body {
     radial-gradient(circle at 50% 80%, rgba(255, 107, 107, 0.25), transparent 40%);
   filter: blur(60px);
   z-index: 0;
+}
+
+body[data-theme='light'] .background-gradient {
+  background: radial-gradient(circle at 20% 20%, rgba(110, 91, 255, 0.25), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(38, 212, 255, 0.2), transparent 45%),
+    radial-gradient(circle at 50% 80%, rgba(255, 177, 107, 0.25), transparent 40%);
 }
 
 .app-shell {
@@ -48,18 +84,24 @@ body {
 .auth-card {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  background: rgba(9, 11, 22, 0.85);
-  border: 1px solid var(--border);
+  background: var(--surface-mid);
+  border: 1px solid var(--surface-border);
   border-radius: 30px;
   box-shadow: var(--shadow);
   overflow: hidden;
   width: min(950px, 100%);
+  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .auth-hero {
   padding: 3rem 3.5rem;
   background: radial-gradient(circle at top right, rgba(110, 91, 255, 0.25), transparent 55%),
-    rgba(10, 11, 24, 0.9);
+    var(--surface-strong);
+}
+
+body[data-theme='light'] .auth-hero {
+  background: radial-gradient(circle at top right, rgba(110, 91, 255, 0.2), transparent 55%),
+    var(--surface-strong);
 }
 
 .auth-hero h1 {
@@ -97,7 +139,7 @@ body {
   padding: 0.75rem 1rem;
   border-radius: 14px;
   border: 1px solid transparent;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface-soft);
   color: var(--muted);
   font-weight: 600;
   cursor: pointer;
@@ -107,7 +149,7 @@ body {
 .tab.active {
   background: var(--accent);
   color: var(--fg);
-  border-color: rgba(255, 255, 255, 0.12);
+  border-color: var(--surface-border);
   box-shadow: 0 15px 35px rgba(110, 91, 255, 0.35);
 }
 
@@ -134,11 +176,11 @@ input,
 select {
   padding: 0.8rem 1rem;
   border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
   color: var(--fg);
   font-size: 1rem;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
+  transition: border 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
 }
 
 .password-input-container {
@@ -159,16 +201,17 @@ select {
   border: none;
   color: var(--muted);
   cursor: pointer;
-  font-size: 1.1rem;
   padding: 0.25rem;
-  border-radius: 6px;
+  border-radius: 8px;
   transition: color 0.2s ease, background 0.2s ease;
   z-index: 1;
+  display: grid;
+  place-items: center;
 }
 
 .password-toggle:hover {
   color: var(--fg);
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--surface-soft);
 }
 
 .password-toggle:active {
@@ -186,6 +229,9 @@ select {
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   margin-top: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .dev-login:hover {
@@ -224,27 +270,51 @@ select:focus {
 .ghost {
   padding: 0.75rem 1.2rem;
   border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--surface-border);
   background: transparent;
   color: var(--fg);
   cursor: pointer;
   font-weight: 500;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.ghost:hover {
+  background: var(--surface-soft);
+  border-color: var(--surface-border);
 }
 
 .icon-button {
   width: 40px;
   height: 40px;
   border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--surface-border);
+  background: var(--surface-soft);
   color: var(--fg);
   display: grid;
   place-items: center;
   cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
-.material-symbol {
-  font-size: 1.3rem;
+.icon-button:hover {
+  background: var(--ghost-hover);
+}
+
+.theme-toggle {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  z-index: 10;
+  backdrop-filter: blur(16px);
+}
+
+.material-symbols-rounded {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.35rem;
+  line-height: 1;
 }
 
 .auth-hint {
@@ -273,10 +343,11 @@ select:focus {
   justify-content: space-between;
   align-items: center;
   padding: 1.5rem 2rem;
-  background: rgba(9, 10, 20, 0.9);
+  background: var(--surface-strong);
   border-radius: 28px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--surface-border);
   box-shadow: var(--shadow);
+  transition: background 0.3s ease, border-color 0.3s ease;
 }
 
 .brand {
@@ -313,10 +384,10 @@ select:focus {
 }
 
 .sports-palette {
-  background: rgba(9, 10, 20, 0.85);
+  background: var(--surface-strong);
   border-radius: 28px;
   padding: 1.8rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--surface-border);
   box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
@@ -347,10 +418,10 @@ select:focus {
   gap: 0.75rem;
   padding: 0.75rem 0.9rem;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface-soft);
+  border: 1px solid var(--surface-border);
   cursor: grab;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
 }
 
 .sport-pill:active {
@@ -365,7 +436,7 @@ select:focus {
   display: grid;
   place-items: center;
   font-size: 1.4rem;
-  font-weight: 700;
+  color: #ffffff;
 }
 
 .sport-info h3 {
@@ -380,10 +451,10 @@ select:focus {
 }
 
 .calendar-area {
-  background: rgba(9, 10, 20, 0.85);
+  background: var(--surface-strong);
   border-radius: 28px;
   padding: 1.5rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--surface-border);
   box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
@@ -407,15 +478,15 @@ select:focus {
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 600;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--surface-border);
 }
 
 .legend-item.planning {
-  background: rgba(123, 92, 255, 0.2);
+  background: var(--legend-planning);
 }
 
 .legend-item.completed {
-  background: rgba(68, 255, 161, 0.2);
+  background: var(--legend-completed);
 }
 
 .calendar-navigation {
@@ -440,18 +511,31 @@ select:focus {
 .nav-button {
   padding: 0.65rem 1rem;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface-soft);
+  border: 1px solid var(--surface-border);
   color: var(--fg);
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.nav-button:hover {
+  background: var(--ghost-hover);
+}
+
+.nav-button .material-symbols-rounded {
+  font-size: 1.2rem;
 }
 
 .calendar-grid {
   position: relative;
   border-radius: 22px;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(10, 11, 24, 0.8);
+  border: 1px solid var(--surface-border);
+  background: var(--surface-strong);
+  transition: background 0.3s ease, border-color 0.3s ease;
 }
 
 .calendar-grid::before {
@@ -472,8 +556,8 @@ select:focus {
   position: sticky;
   top: 0;
   z-index: 2;
-  background: rgba(9, 10, 20, 0.95);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--surface-strong);
+  border-bottom: 1px solid var(--surface-border);
 }
 
 .calendar-header-cell {
@@ -498,16 +582,16 @@ select:focus {
   padding: 0.4rem 0.6rem;
   font-size: 0.75rem;
   color: var(--muted);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
-  background: rgba(9, 10, 20, 0.6);
+  border-bottom: 1px solid var(--surface-soft);
+  background: var(--surface-strong);
   position: sticky;
   left: 0;
   z-index: 1;
 }
 
 .drop-cell {
-  border-left: 1px solid rgba(255, 255, 255, 0.04);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  border-left: 1px solid var(--surface-soft);
+  border-bottom: 1px solid var(--surface-soft);
   position: relative;
   min-height: 28px;
   overflow: visible;
@@ -563,11 +647,15 @@ select:focus {
   backdrop-filter: blur(14px);
 }
 
+body[data-theme='light'] .modal {
+  background: rgba(11, 13, 26, 0.35);
+}
+
 .modal-content {
   width: min(560px, 90%);
-  background: rgba(9, 10, 20, 0.95);
+  background: var(--surface-strong);
   border-radius: 26px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--surface-border);
   box-shadow: var(--shadow);
   padding: 2.2rem;
   position: relative;
@@ -586,10 +674,11 @@ select:focus {
   width: 60px;
   height: 60px;
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--surface-soft);
   display: grid;
   place-items: center;
   font-size: 2rem;
+  color: #ffffff;
 }
 
 .modal h3 {
@@ -639,8 +728,8 @@ select:focus {
 .chip {
   padding: 0.45rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--surface-border);
+  background: var(--surface-soft);
   color: var(--fg);
   font-size: 0.8rem;
   cursor: pointer;
@@ -649,7 +738,7 @@ select:focus {
 
 .chip.selected {
   background: var(--accent);
-  border-color: rgba(255, 255, 255, 0.25);
+  border-color: transparent;
 }
 
 .session-type {
@@ -669,9 +758,9 @@ select:focus {
   right: 2rem;
   bottom: 2rem;
   width: min(360px, 90vw);
-  background: rgba(9, 10, 20, 0.95);
+  background: var(--surface-strong);
   border-radius: 26px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--surface-border);
   box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
@@ -697,7 +786,7 @@ select:focus {
 .ai-message {
   padding: 0.75rem 1rem;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-soft);
   font-size: 0.9rem;
   line-height: 1.4;
 }
@@ -734,6 +823,10 @@ select:focus {
   }
   .auth-forms {
     padding: 2rem;
+  }
+  .theme-toggle {
+    top: 1rem;
+    right: 1rem;
   }
   .topbar {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add persistent light/dark theme support with dark as the default
- refresh the UI with Material Symbols icons and theme-aware styling updates
- scaffold an images directory for future assets

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68da13169cc083288a253ceafa82d41c