### PR TITLE
Improve session editing workflow and add sport documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation Sports
+
+Ce dossier centralise des fiches pratiques pour chaque sport disponible dans l'application Sport Calendar. Chaque fiche décrit les objectifs principaux, les points techniques clés, des idées de séances types, des conseils de préparation et de récupération ainsi que du vocabulaire utile pour alimenter l'assistant IA.
+
+## Sports couverts
+
+- [Judo](judo.md)
+- [Jiu-Jitsu brésilien](jjb.md)
+- [Musculation](strength.md)
+- [Yoga](yoga.md)
+- [Stretching](stretch.md)
+- [Cardio](cardio.md)
+
+N'hésite pas à enrichir ces fiches au fur et à mesure des retours des utilisateurs afin d'améliorer les suggestions générées par le coach virtuel.

--- a/docs/cardio.md
+++ b/docs/cardio.md
@@ -1,0 +1,42 @@
+# Cardio / Endurance
+
+## Aperçu rapide
+- Englobe les activités visant à améliorer la capacité cardiovasculaire et respiratoire (course, vélo, rameur, HIIT, intervalles).
+- Peut être orienté endurance fondamentale, seuil, VO2max ou travail mixte.
+- Indispensable pour la santé générale, la gestion du poids et la performance dans de nombreux sports.
+
+## Objectifs d'entraînement fréquents
+- Développer l'endurance aérobie de base (zones d'effort 1-2).
+- Augmenter la capacité anaérobie et la tolérance au lactate via intervalles intenses.
+- Améliorer la vitesse spécifique sur une distance cible (5 km, 10 km, semi-marathon, etc.).
+- Renforcer le système cardiorespiratoire pour d'autres disciplines (sports de combat, musculation).
+
+## Paramètres clés
+- **Fréquence cardiaque** : travail par zones (Z1 récupération, Z2 endurance, Z3 tempo, Z4 seuil, Z5 VO2max).
+- **RPE** : échelle subjective 1-10 utile sans cardiofréquencemètre.
+- **Volume hebdomadaire** : ajusté selon niveau (débutant 2-3 séances, intermédiaire 3-5, avancé 5+).
+- **Variabilité des séances** : continuous run, fartlek, intervalles courts/longs, tempo run, sorties longues.
+
+## Structure type de séance (exemples)
+- **Endurance fondamentale (45-60 min)** : allure confortable, respiration aisée.
+- **HIIT 30/30 (20 min)** : 10 répétitions de 30 s intense / 30 s repos actif + échauffement/retour au calme.
+- **Intervalles longs** : 4 x 5 min à allure seuil avec 2 min de récupération.
+- **Sortie longue** : 60-90 min à intensité modérée pour construire l'endurance.
+
+## Conseils de coaching IA
+- Demander le mode de cardio préféré et l'accès au matériel (tapis, vélo, extérieur).
+- Intégrer échauffement (10 min progressif) et retour au calme (5-10 min + étirements légers).
+- Suggérer un suivi : journal de course, temps sur segments, variabilité de la FC.
+- Mentionner l'importance de la récupération (nutrition, sommeil, jours faciles) pour éviter le surentraînement.
+
+## Prévention et récupération
+- Augmenter le volume progressivement (règle des 10 % par semaine).
+- Intégrer du renforcement musculaire (gainage, travail pied/cheville) pour limiter les blessures.
+- Surveiller les signaux de fatigue : FC au repos élevée, sommeil perturbé, baisse de motivation.
+
+## Vocabulaire utile
+- **VO2max** : capacité maximale d'utilisation de l'oxygène.
+- **Fartlek** : jeu de vitesse libre.
+- **Interval Training** : alternance effort/repos.
+- **Seuil lactique** : intensité où l'acide lactique s'accumule rapidement.
+- **Negative split** : deuxième moitié plus rapide que la première.

--- a/docs/jjb.md
+++ b/docs/jjb.md
@@ -1,0 +1,43 @@
+# Jiu-Jitsu brésilien (JJB)
+
+## Aperçu rapide
+- Discipline axée sur le grappling et la soumission, sans projections violentes.
+- Les séances mélangent drills techniques, positions spécifiques et combats (sparring) en intensité variable.
+- Une grande partie du travail se fait au sol avec kimono (gi) ou sans kimono (no-gi).
+
+## Objectifs d'entraînement fréquents
+- Construire un jeu solide depuis les positions clés : garde fermée, demi-garde, monté, dos.
+- Développer la capacité à passer la garde et à stabiliser les positions dominantes.
+- Améliorer la défense : escapes, inversions, gestion de la pression adverse.
+- Préparer les compétitions IBJJF ou ADCC : temps de combat, gestion des points/avantages.
+
+## Compétences techniques clés
+- **Attaques de garde** : armbar, triangle, omoplata, berimbolo.
+- **Passages de garde** : toreando, knee slice, over/under, leg drag.
+- **Contrôles** : side control, monté, dos (hooks + ceinture).
+- **Soumissions avancées** : étranglements en gi (collar choke, bow & arrow), étranglements sans gi (rear naked choke, guillotine), clés de jambe (heel hook, toe hold).
+
+## Structure type de séance
+1. **Mise en route (10 min)** : mobilité, shrimping, drills de déplacements au sol.
+2. **Technique du jour (20-30 min)** : séquence de positions progressives avec drilling guidé.
+3. **Sparring situationnel (15-20 min)** : départ dans une position imposée, travail en aller/retour.
+4. **Sparring libre (15-30 min)** : rounds chronométrés, intensité adaptée au niveau.
+5. **Décompression** : étirements axés sur la colonne et les hanches.
+
+## Conseils de coaching IA
+- Adapter les recommandations selon le style (garde, passage, soumission) et le format (gi/no-gi).
+- Encourager la planification par thèmes : semaine « garde fermée », semaine « passages explosifs », etc.
+- Mentionner la gestion de la respiration et de la tension musculaire pour éviter la fatigue prématurée.
+- Proposer des exercices de renforcement ciblés : tirages, gainage anti-rotation, grip strength.
+
+## Prévention et récupération
+- Attention aux blessures de cou, lombaires, coudes et doigts.
+- Conseiller l'échauffement des cervicales et du bas du dos avant chaque séance.
+- Favoriser l'équilibre musculaire : renforcement du haut du dos, mobilité des hanches et des épaules.
+
+## Vocabulaire utile
+- **Guard / Garde** : position de défense au sol.
+- **Sweep / Renversement** : inverser les positions pour passer au-dessus.
+- **Submission / Soumission** : technique qui force l'abandon.
+- **Passing** : passer la garde pour atteindre une position dominante.
+- **Rolling** : sparring libre.

--- a/docs/judo.md
+++ b/docs/judo.md
@@ -1,0 +1,43 @@
+# Judo
+
+## Aperçu rapide
+- Art martial olympique japonais basé sur les projections, le contrôle au sol et les immobilisations.
+- Travail technique très précis combiné à un engagement physique important.
+- Les séances alternent généralement entre apprentissage technique (uchi-komi), travail situationnel (randori) et préparation physique spécifique.
+
+## Objectifs d'entraînement fréquents
+- Améliorer la qualité des projections (tachi-waza) et des transitions vers le sol (ne-waza).
+- Développer la puissance de hanches, la mobilité et la vitesse de réaction.
+- Renforcer l'endurance de préhension pour le kumi-kata.
+- Préparer les compétitions : gestion du poids, stratégie de combat, travail des séquences préférées.
+
+## Compétences techniques clés
+- **Tachi-waza** : ippon seoi nage, o-soto gari, uchi mata, tai otoshi.
+- **Ne-waza** : immobilisations (osae-komi), étranglements (shime-waza), clés (kansetsu-waza).
+- **Kumi-kata** : variations de saisies (standard, croisée, inversée) selon les adversaires.
+- **Déplacements** : shintai (avancer/reculer) et tai sabaki (pivot) pour créer l'ouverture.
+
+## Structure type de séance
+1. **Échauffement dynamique (10-15 min)** : mobilisations articulaires, ukemi, déplacements en garde.
+2. **Uchi-komi / nage-komi (15-20 min)** : répétitions techniques avec partenaire, travail de timing.
+3. **Randori dirigés (15-25 min)** : thématiques (grip fighting, tachi-waza, ne-waza, transitions).
+4. **Préparation physique spécifique (10-15 min)** : circuits grip strength, tractions, gainage.
+5. **Retour au calme** : étirements ciblés sur hanches, épaules, dos.
+
+## Conseils de coaching IA
+- Poser des questions sur le niveau (débutant, ceinture intermédiaire, compétiteur) pour ajuster les contenus.
+- Suggérer des séries d'uchi-komi avec durée ou nombre de répétitions plutôt qu'un volume total.
+- Inclure des conseils tactiques : contrôle du rythme, variations de garde, préparation des attaques combinées.
+- Encourager la tenue d'un journal technique (technique clé + sensations ressenties).
+
+## Prévention et récupération
+- Surveiller les blessures aux épaules, genoux et doigts (surcharge de kumi-kata).
+- Recommander du renforcement musculaire équilibré (rotateurs, gainage, ischios).
+- Souligner l'importance de la récupération active : mobilité, automassages, sommeil.
+
+## Vocabulaire utile
+- **Uchi-komi** : répétition sans projection.
+- **Randori** : combat d'entraînement.
+- **Ne-waza** : travail au sol.
+- **Kumi-kata** : bataille de saisie.
+- **Seoi nage / O-soto gari** : projections emblématiques.

--- a/docs/strength.md
+++ b/docs/strength.md
@@ -1,0 +1,44 @@
+# Musculation / Strength Training
+
+## Aperçu rapide
+- Vise l'amélioration de la force maximale, de l'hypertrophie et de la puissance.
+- Inclut des méthodes variées : force pure (low reps), hypertrophie (8-15 reps), travail fonctionnel.
+- S'articule souvent autour de mouvements polyarticulaires (squat, soulevé de terre, développé couché) complétés par des exercices d'assistance.
+
+## Objectifs d'entraînement fréquents
+- Développer la force sur les mouvements de base (squat, bench, deadlift, overhead press).
+- Augmenter la masse musculaire avec des volumes ciblés par groupe musculaire.
+- Améliorer l'endurance musculaire ou la puissance selon les cycles.
+- Corriger les déséquilibres et renforcer la stabilité (gainage, muscles posturaux).
+
+## Paramètres de programmation
+- **Force** : 3-6 séries de 1-5 reps à 85-95 % 1RM, repos longs (3-5 min).
+- **Hypertrophie** : 3-5 séries de 6-12 reps à 65-80 % 1RM, tempo contrôlé, repos 60-120 s.
+- **Puissance** : mouvements explosifs (haltérophilie, plyométrie), 3-5 séries de 3-5 reps, repos 2-3 min.
+- **Full body / Split** : organisation hebdomadaire selon disponibilité (full body 3x/sem, upper/lower, push/pull/legs).
+
+## Structure type de séance
+1. **Activation / mobilité (10 min)** : mobilité articulaire, respiration diaphragmatique, activation spécifique (band pull apart, glute bridge).
+2. **Mouvement principal** : progression linéaire ou ondulatoire, suivi d'un top set + back-off.
+3. **Supplémentaires** : exercices d'assistance pour cibler points faibles (row, fentes, dips, hip thrust).
+4. **Conditioning léger** : finisher cardio léger ou circuit core si besoin.
+5. **Retour au calme** : étirements légers, auto-massage.
+
+## Conseils de coaching IA
+- Vérifier le matériel disponible (barre, haltères, machines, poids du corps).
+- Adapter les recommandations au niveau (débutant : charges modérées + focus technique; intermédiaire : suivi des charges; avancé : planification cyclique).
+- Mentionner la surcharge progressive : augmenter charge, volume ou densité progressivement.
+- Insister sur la technique : amplitude complète, gainage, trajectoire de barre.
+- Suggérer un suivi des performances (carnet d'entraînement, RPE).
+
+## Prévention et récupération
+- Équilibrer poussées/tractions pour protéger les épaules.
+- Inclure du travail de mobilité pour hanches, chevilles, colonne.
+- Gestion de la fatigue : sommeil, nutrition riche en protéines, deload toutes les 4-6 semaines.
+
+## Vocabulaire utile
+- **1RM** : charge maximale sur une répétition.
+- **RPE** : échelle de perception de l'effort.
+- **Superset / Giant set** : enchaînement d'exercices sans repos.
+- **Tempo** : vitesse d'exécution (ex : 3-1-1-0).
+- **Deload** : semaine de récupération active avec volume/intensité réduits.

--- a/docs/stretch.md
+++ b/docs/stretch.md
@@ -1,0 +1,41 @@
+# Stretching / Mobilité
+
+## Aperçu rapide
+- Vise à améliorer l'amplitude articulaire, relâcher les tensions et favoriser la récupération.
+- Inclut des approches variées : stretching statique, dynamique, PNF, mobility flows.
+- Souvent utilisé comme complément pour sportifs intensifs ou sédentaires.
+
+## Objectifs fréquents
+- Augmenter la flexibilité globale ou ciblée (ischio-jambiers, hanches, épaules, colonne).
+- Préparer le corps à l'effort par des mouvements dynamiques contrôlés.
+- Faciliter la récupération post-entraînement, réduire les courbatures.
+- Améliorer la posture et la conscience corporelle.
+
+## Types de stretching
+- **Dynamique** : mouvements contrôlés sur toute l'amplitude (leg swings, rotations).
+- **Statique** : maintien de 20-60 s en respirant profondément.
+- **PNF (Proprioceptive Neuromuscular Facilitation)** : contraction-relâchement pour gagner en amplitude.
+- **Mobilité active** : combinaison de force et d'étirement (CARS, 90/90 transitions).
+
+## Structure type de séance
+1. **Échauffement léger** : cardio doux ou mobilité articulaire générale.
+2. **Séquence ciblée** : enchaînement d'étirements spécifiques selon la zone.
+3. **Techniques de respiration** : cohérence cardiaque, respiration 4-7-8 pour accentuer la détente.
+4. **Retour au calme** : posture restorative, automassage (foam roller, balle).
+
+## Conseils de coaching IA
+- Identifier les zones prioritaires et la fréquence souhaitée (quotidienne, après sport, journée de repos).
+- Proposer des durées précises (ex : 3 séries de 30 s par côté) et des points d'alignement.
+- Suggérer des progressions (ex : passer du 90/90 assisté au 90/90 sans support).
+- Rappeler de ne jamais forcer : sensation d'étirement mais pas de douleur aiguë.
+
+## Prévention et récupération
+- Coupler le stretching à du renforcement léger pour stabiliser la nouvelle amplitude.
+- Hydratation suffisante et sommeil favorisent l'amélioration de la mobilité.
+- Intégrer des auto-massages pour dénouer les trigger points.
+
+## Vocabulaire utile
+- **ROM (Range of Motion)** : amplitude de mouvement.
+- **PNF** : méthode contract-relax.
+- **CARS** : Controlled Articular Rotations.
+- **Trigger point** : zone de tension musculaire localisée.

--- a/docs/yoga.md
+++ b/docs/yoga.md
@@ -1,0 +1,44 @@
+# Yoga
+
+## Aperçu rapide
+- Pratique holistique combinant postures (asanas), respiration (pranayama) et méditation.
+- Différents styles avec intensité variable : Vinyasa (dynamique), Hatha (modéré), Yin (statique), Power (athlétique), Restorative (détente).
+- Vise la conscience corporelle, la mobilité et la gestion du stress.
+
+## Objectifs d'entraînement fréquents
+- Améliorer la flexibilité, l'équilibre et la force fonctionnelle.
+- Développer la conscience respiratoire et la capacité à rester concentré.
+- Favoriser la récupération active entre séances intenses d'autres sports.
+- Réduire les tensions musculaires et le stress chronique.
+
+## Éléments clés d'une séance
+1. **Centrée / respiration initiale** : installation, scans corporels, respiration nasale.
+2. **Échauffement** : salutations au soleil, mouvements articulaires progressifs.
+3. **Séquence principale** : enchaînements (flows) ciblés selon l'objectif (équilibres, backbends, hanches).
+4. **Pics de posture** : asanas plus exigeantes tenues 3-8 respirations.
+5. **Retour au calme** : postures de récupération, pranayama, méditation, savasana.
+
+## Adaptations par style
+- **Vinyasa** : transitions fluides, coordination respiration/mouvement, rythme soutenu.
+- **Hatha** : maintien statique, travail d'alignement, intensité modérée.
+- **Yin** : postures au sol tenues 2-5 minutes pour étirer les tissus profonds.
+- **Power** : inspiré du fitness, inclut des postures de force et des séquences cardio.
+- **Restauratif / Respiratoire** : accessoires (bolsters, sangles) pour relâcher le système nerveux.
+
+## Conseils de coaching IA
+- Demander le niveau (débutant, intermédiaire, avancé) et l'objectif (mobilité, relaxation, renforcement).
+- Indiquer la durée des phases de respiration et les variations possibles avec accessoires.
+- Mentionner des options pour soulager les poignets/épaules (chien tête en bas sur avant-bras, utilisation de blocs).
+- Intégrer des rappels de sécurité : alignement genoux-chevilles, engagement du centre, ne jamais forcer les étirements.
+
+## Prévention et récupération
+- Rester dans une amplitude contrôlée pour éviter les hyperextensions.
+- Encourager l'hydratation et un environnement calme pour les séances yin/restauratives.
+- Après une séance intense, recommander des étirements doux et un temps de respiration pour revenir au calme.
+
+## Vocabulaire utile
+- **Pranayama** : techniques de respiration.
+- **Asana** : posture.
+- **Vinyasa** : séquence fluide reliant les postures.
+- **Drishti** : point focal du regard.
+- **Savasana** : posture finale de relaxation.


### PR DESCRIPTION
## Summary
- allow editing existing sessions without crashing when data is incomplete and avoid overriding creation timestamps
- add updatedAt tracking when rescheduling sessions via drag and drop
- document each supported sport with training guidance for the AI assistant

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da1d0949908328bb1b71605bf0d800